### PR TITLE
feat: add MCP service to docker-compose

### DIFF
--- a/docs/lmstudio_xinference_setup_ja.md
+++ b/docs/lmstudio_xinference_setup_ja.md
@@ -1,0 +1,87 @@
+# Lm Studio と Xinference を利用した Memobase サーバー設定
+
+このドキュメントでは、Memobase サーバーをローカルの Lm Studio（LLM）と Xinference（Embedding）に接続する方法を示します。
+
+## 前提条件
+
+- Docker で Memobase サーバーを起動することを想定しています。
+- Lm Studio は OpenAI 互換 API を提供している必要があります。
+- Xinference は OpenAI 互換の Embedding API を有効にした状態で起動しておきます。
+
+## 1. Lm Studio の準備
+
+1. [Lm Studio](https://lmstudio.ai/) をインストールし、アプリを起動します。
+2. "Local Server" や "API" などのメニューから OpenAI 互換サーバーを開始し、ポート番号（例: `1234`）を確認します。
+3. サーバーが起動すると `http://localhost:1234/v1` で OpenAI 互換エンドポイントが利用できます。
+   - Docker コンテナ内からアクセスする場合は `http://host.docker.internal:1234/v1` を利用します。
+4. 認証キーは任意の文字列で構いません（例: `lm-studio`）。
+
+## 2. Xinference の準備
+
+1. Xinference をインストールしローカルサーバーを起動します。
+   ```bash
+   pip install "xinference[all]"
+   xinference-local --host 0.0.0.0 --port 9997
+   ```
+2. Web UI (例: `http://localhost:9997`) から埋め込みモデルを追加します。`text-embedding-bge-small` など OpenAI 互換の埋め込みモデルをロードしてください。
+3. モデルの次元数を確認します（`text-embedding-bge-small` は 512 次元など）。
+4. 認証キーは任意の文字列で構いません（例: `xinference`）。
+
+## 3. Memobase サーバーの設定
+
+設定は `config.yaml` を編集する方法と、環境変数で指定する方法の 2 通りがあります。
+
+### 3.1 `config.yaml` を編集する
+
+`src/server/api/config.yaml` を編集し、以下の項目を設定します。
+
+```yaml
+llm_api_key: lm-studio
+llm_base_url: http://host.docker.internal:1234/v1
+best_llm_model: llama-3.1-8b-instruct
+
+embedding_provider: openai
+embedding_api_key: xinference
+embedding_base_url: http://host.docker.internal:9997/v1
+embedding_model: text-embedding-bge-small
+embedding_dim: 512  # モデルの次元数に合わせて調整
+```
+
+### 3.2 環境変数で設定する
+
+`src/server/.env` に以下を追記すると、上記と同じ設定が環境変数として読み込まれます。
+
+```dotenv
+MEMOBASE_LLM_API_KEY=lm-studio
+MEMOBASE_LLM_BASE_URL=http://host.docker.internal:1234/v1
+MEMOBASE_BEST_LLM_MODEL=llama-3.1-8b-instruct
+
+MEMOBASE_EMBEDDING_PROVIDER=openai
+MEMOBASE_EMBEDDING_API_KEY=xinference
+MEMOBASE_EMBEDDING_BASE_URL=http://host.docker.internal:9997/v1
+MEMOBASE_EMBEDDING_MODEL=text-embedding-bge-small
+MEMOBASE_EMBEDDING_DIM=512
+```
+
+環境変数は `config.yaml` より優先されます。
+
+- コンテナを使わずに直接実行する場合は `host.docker.internal` を `localhost` に置き換えてください。
+- `embedding_dim` は使用するモデルの仕様に合わせて変更してください。
+
+## 4. サーバーの起動
+
+設定が完了したら、`docker-compose` で Memobase サーバー本体と MCP サーバーを同時に起動します。
+
+```bash
+cd src/server
+cp .env.example .env
+cp api/config.yaml.example api/config.yaml  # まだ作成していない場合
+# 上記の設定を api/config.yaml に反映
+
+docker-compose build
+docker-compose up
+```
+
+起動後、内部ネットワーク経由で MCP サーバーが `memobase-server-api` に接続され、`MCP_EXPORT_PORT`（既定値: `8050`）で SSE エンドポイントが公開されます。
+
+これで、Memobase サーバーは Lm Studio を LLM として、Xinference を Embedding として利用しつつ、MCP 経由で長期記憶を操作できるようになります。

--- a/docs/mcp_server_endpoints_ja.md
+++ b/docs/mcp_server_endpoints_ja.md
@@ -1,0 +1,54 @@
+# MCP サーバーのエンドポイント
+
+Memobase に付属する MCP サーバーが提供するエンドポイントと設定方法をまとめます。
+
+## SSE トランスポート
+
+HTTP の Server-Sent Events (SSE) を利用する場合、以下の URL でアクセスできます。
+
+```
+http://<HOST>:<PORT>/sse
+```
+
+- `HOST` と `PORT` は環境変数で指定します。既定値は `HOST=0.0.0.0`、`PORT=8050` です。
+- Docker コンテナ内からホスト側の MCP サーバーに接続する場合は `localhost` の代わりに `host.docker.internal` を利用してください。
+- `docker-compose` で起動した場合は、`.env` の `MCP_EXPORT_PORT`（既定値: `8050`）を公開ポートとして利用できます。
+
+### 例: Cursor から接続する場合
+
+`~/.cursor/mcp.json` に以下を追記します。
+
+```json
+{
+  "mcpServers": {
+    "memobase": {
+      "transport": "sse",
+      "url": "http://localhost:8050/sse"
+    }
+  }
+}
+```
+
+## Stdio トランスポート
+
+`TRANSPORT=stdio` を指定すると、HTTP エンドポイントではなく標準入出力で通信します。MCP クライアント側でコマンド実行と環境変数設定を行ってください。
+
+### 例: Stdio を利用する設定
+
+```json
+{
+  "mcpServers": {
+    "memobase": {
+      "command": "python",
+      "args": ["path/to/src/mcp/src/main.py"],
+      "env": {
+        "TRANSPORT": "stdio",
+        "MEMOBASE_API_KEY": "YOUR-API-KEY",
+        "MEMOBASE_BASE_URL": "YOUR-MEMOBASE-URL"
+      }
+    }
+  }
+}
+```
+
+これらのエンドポイント設定により、Memobase の長期記憶機能を MCP 対応クライアントから利用できます。

--- a/src/server/.env.example
+++ b/src/server/.env.example
@@ -16,3 +16,19 @@ USE_CORS=false
 
 PROJECT_ID="memobase_dev"
 ACCESS_TOKEN="secret"
+
+# LLM / Embedding configuration for Lm Studio + Xinference
+MEMOBASE_LLM_API_KEY="lm-studio"
+MEMOBASE_LLM_BASE_URL="http://host.docker.internal:1234/v1"
+MEMOBASE_BEST_LLM_MODEL="llama-3.1-8b-instruct"
+
+MEMOBASE_EMBEDDING_PROVIDER="openai"
+MEMOBASE_EMBEDDING_API_KEY="xinference"
+MEMOBASE_EMBEDDING_BASE_URL="http://host.docker.internal:9997/v1"
+MEMOBASE_EMBEDDING_MODEL="text-embedding-bge-small"
+MEMOBASE_EMBEDDING_DIM="512"
+
+# MCP server configuration
+MCP_EXPORT_PORT="8050"
+MEMOBASE_BASE_URL="http://memobase-server-api:8000/"
+MEMOBASE_API_KEY="secret"

--- a/src/server/docker-compose.yml
+++ b/src/server/docker-compose.yml
@@ -57,6 +57,23 @@ services:
     volumes:
       - ./api/config.yaml:/app/config.yaml
 
+  memobase-mcp:
+    platform: linux/amd64
+    container_name: memobase-mcp
+    build:
+      context: ../mcp
+    environment:
+      - MEMOBASE_BASE_URL=${MEMOBASE_BASE_URL}
+      - MEMOBASE_API_KEY=${MEMOBASE_API_KEY}
+      - HOST=${MCP_HOST:-0.0.0.0}
+      - PORT=${MCP_PORT:-8050}
+      - TRANSPORT=${MCP_TRANSPORT:-sse}
+    depends_on:
+      memobase-server-api:
+        condition: service_started
+    ports:
+      - '${MCP_EXPORT_PORT:-8050}:8050'
+
 volumes:
   memobase-server-db:
     driver: local


### PR DESCRIPTION
## Summary
- run MCP server container together with Memobase services via docker-compose
- document joint startup and port configuration in Japanese guides
- add MCP-related variables to example `.env`

## Testing
- `pip install python-dotenv`
- `pytest` *(fails: ImportPathMismatchError: ('tests.conftest', '/workspace/memobase/src/client/tests/conftest.py', PosixPath('/workspace/memobase/src/server/api/tests/conftest.py')))*

------
https://chatgpt.com/codex/tasks/task_e_68a5d71565a0832fa28ef5e569f00d44